### PR TITLE
Add `mips64` Toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/.scuba.yml
+++ b/.scuba.yml
@@ -1,1 +1,1 @@
-image: ghcr.io/xyrisos/xyris-build/xyris-build:3.3.0
+image: ghcr.io/xyrisos/xyris-build/xyris-build:4.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH="$CROSS_PREFIX/bin:$PATH"
 WORKDIR /tmp
 RUN export MAKEFLAGS="${CROSS_MAKEFLAGS}"; \
     wget "https://ftp.gnu.org/pub/gnu/binutils/binutils-${BIN_VER}.tar.gz"; \
-    tar -xf binutils-${BIN_VER}.tar.gz; \
+    tar -xf "binutils-${BIN_VER}.tar.gz"; \
     for TARGET in "i686-elf" "mips64-elf"; do \
         echo "Building binutils for ${TARGET}"; \
         mkdir "build-binutils-${TARGET}"; \
@@ -23,15 +23,15 @@ RUN export MAKEFLAGS="${CROSS_MAKEFLAGS}"; \
         ../binutils-${BIN_VER}/configure --target="${TARGET}" --prefix="${CROSS_PREFIX}" --with-sysroot --disable-nls --disable-werror; \
         make; \
         make install-strip; \
-        make clean; \
         cd /tmp; \
+        rm -r "build-binutils-${TARGET}"; \
     done; \
-    rm -rf ./*;
+    rm "binutils-${BIN_VER}.tar.gz";
 # Build GCC
 WORKDIR /tmp
 RUN export MAKEFLAGS="${CROSS_MAKEFLAGS}"; \
     wget "https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VER}/gcc-${GCC_VER}.tar.gz"; \
-    tar -xf gcc-${GCC_VER}.tar.gz; \
+    tar -xf "gcc-${GCC_VER}.tar.gz"; \
     for TARGET in "i686-elf" "mips64-elf"; do \
         echo "Building binutils for ${TARGET}"; \
         mkdir "build-gcc-${TARGET}"; \
@@ -41,10 +41,10 @@ RUN export MAKEFLAGS="${CROSS_MAKEFLAGS}"; \
         make all-target-libgcc; \
         make install-strip-gcc; \
         make install-strip-target-libgcc; \
-        make clean; \
         cd /tmp; \
+        rm -r "build-gcc-${TARGET}"; \
     done; \
-    rm -rf ./*;
+    rm "gcc-${GCC_VER}.tar.gz";
 # Packages necessary to build Xyris and docs
 ARG TOOLCHAIN_PKGS="nasm scons doxygen graphviz jq"
 # Useful tools for debugging and image creation

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,9 @@ ARG BUILD_PKGS="make wget bison flex mpc1-dev gmp-dev mpfr-dev texinfo build-bas
 RUN apk update; \
     apk add --no-cache ${BUILD_PKGS}
 # Environment variables for cross compiler
-ENV BIN_VER="2.37"
-ENV GCC_VER="11.2.0"
+ENV BIN_VER="2.39"
+ENV GCC_VER="12.2.0"
 ENV CROSS_PREFIX="/opt/cross"
-ENV CROSS_TARGET="i686-elf"
 ENV CROSS_MAKEFLAGS="-j6"
 ENV PATH="$CROSS_PREFIX/bin:$PATH"
 # Build Binutils
@@ -17,28 +16,34 @@ WORKDIR /tmp
 RUN export MAKEFLAGS="${CROSS_MAKEFLAGS}"; \
     wget "https://ftp.gnu.org/pub/gnu/binutils/binutils-${BIN_VER}.tar.gz"; \
     tar -xf binutils-${BIN_VER}.tar.gz; \
-    rm -rf binutils-${BIN_VER}.tar; \
-    mkdir build-binutils; \
-    cd build-binutils; \
-    ../binutils-${BIN_VER}/configure --target="${CROSS_TARGET}" --prefix="${CROSS_PREFIX}" --with-sysroot --disable-nls --disable-werror; \
-    make; \
-    make install-strip; \
-    cd /tmp; \
+    for TARGET in "i686-elf" "mips64-elf"; do \
+        echo "Building binutils for ${TARGET}"; \
+        mkdir "build-binutils-${TARGET}"; \
+        cd "build-binutils-${TARGET}"; \
+        ../binutils-${BIN_VER}/configure --target="${TARGET}" --prefix="${CROSS_PREFIX}" --with-sysroot --disable-nls --disable-werror; \
+        make; \
+        make install-strip; \
+        make clean; \
+        cd /tmp; \
+    done; \
     rm -rf ./*;
 # Build GCC
 WORKDIR /tmp
 RUN export MAKEFLAGS="${CROSS_MAKEFLAGS}"; \
     wget "https://ftp.gnu.org/gnu/gcc/gcc-${GCC_VER}/gcc-${GCC_VER}.tar.gz"; \
     tar -xf gcc-${GCC_VER}.tar.gz; \
-    rm -rf gcc-${GCC_VER}.tar.gz; \
-    mkdir build-gcc; \
-    cd build-gcc; \
-    ../gcc-${GCC_VER}/configure --target="${CROSS_TARGET}" --prefix="${CROSS_PREFIX}" --disable-nls --enable-languages=c,c++ --without-headers; \
-    make all-gcc; \
-    make all-target-libgcc; \
-    make install-strip-gcc; \
-    make install-strip-target-libgcc; \
-    cd /tmp; \
+    for TARGET in "i686-elf" "mips64-elf"; do \
+        echo "Building binutils for ${TARGET}"; \
+        mkdir "build-gcc-${TARGET}"; \
+        cd "build-gcc-${TARGET}"; \
+        ../gcc-${GCC_VER}/configure --target="${TARGET}" --prefix="${CROSS_PREFIX}" --disable-nls --enable-languages=c,c++ --without-headers; \
+        make all-gcc; \
+        make all-target-libgcc; \
+        make install-strip-gcc; \
+        make install-strip-target-libgcc; \
+        make clean; \
+        cd /tmp; \
+    done; \
     rm -rf ./*;
 # Packages necessary to build Xyris and docs
 ARG TOOLCHAIN_PKGS="nasm scons doxygen graphviz jq"

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+    ],
+    "settings": {}
+}


### PR DESCRIPTION
No immediate plans to add a mips64 build of Xyris, but there is a plan to do so in the future (with hardware testing on an Cavium OCTEON).